### PR TITLE
fix(ci): checkout correct ref for reproducible F-Droid builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -45,6 +48,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -66,6 +72,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -85,6 +94,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -106,6 +118,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -129,6 +144,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -154,6 +172,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -222,6 +243,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: Download APK Artifact
         uses: actions/download-artifact@v4.1.7


### PR DESCRIPTION
Add `ref: ${{ github.ref }}` and `fetch-depth: 0` to all checkout steps in the release workflow.

This ensures APKs are built from the exact tagged commit that triggered the workflow, rather than checking out the default branch (main). This fixes the META-INF/version-control-info.textproto revision mismatch that was causing F-Droid reproducible build failures.

The `fetch-depth: 0` is also required so the Android Gradle Plugin can properly embed the correct Git SHA in the APK's VCS metadata.

Fixes #14

cc: @licaon-kter