### PR TITLE
Support text file attachments (markdown, txt, json, etc.)

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -28,6 +28,14 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/markdown" />
+                <data android:mimeType="text/x-markdown" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/RemoteDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/RemoteDataRepository.kt
@@ -27,6 +27,7 @@ import com.inspiredandroid.kai.ui.chat.toGroqMessageDto
 import com.inspiredandroid.kai.ui.settings.SettingsModel
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.mimeType
+import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.readBytes
 import kai.composeapp.generated.resources.Res
 import kai.composeapp.generated.resources.default_soul
@@ -373,19 +374,50 @@ class RemoteDataRepository(
         // Read file bytes outside of StateFlow.update (readBytes is suspend)
         val rawBytes = file?.readBytes()
         val fileMimeType = file?.mimeType()?.toString()
-        val fileData = rawBytes?.let { bytes ->
-            val compressed = compressImageBytes(bytes, fileMimeType ?: "image/jpeg")
-            Base64.encode(compressed)
-        }
-        val effectiveMimeType = if (rawBytes != null && fileMimeType?.startsWith("image/") == true) "image/jpeg" else fileMimeType
+        val fileName = file?.name
 
-        if (question != null) {
+        val isImageFile = fileMimeType?.startsWith("image/") == true ||
+            fileMimeType?.startsWith("video/") == true
+
+        // For image/video files: compress and base64-encode for vision APIs
+        // For text files: decode as UTF-8 and prepend to question content
+        val fileData: String?
+        val effectiveMimeType: String?
+        val effectiveQuestion: String?
+
+        if (rawBytes != null && isImageFile) {
+            val compressed = compressImageBytes(rawBytes, fileMimeType ?: "image/jpeg")
+            fileData = Base64.encode(compressed)
+            effectiveMimeType = "image/jpeg"
+            effectiveQuestion = question
+        } else if (rawBytes != null) {
+            // Text-based file: read as UTF-8 and prepend to the user's question
+            val textContent = rawBytes.decodeToString()
+            val header = if (fileName != null) "--- File: $fileName ---" else "--- Attached file ---"
+            effectiveQuestion = buildString {
+                appendLine(header)
+                appendLine(textContent)
+                appendLine("---")
+                if (!question.isNullOrBlank()) {
+                    appendLine()
+                    append(question)
+                }
+            }
+            fileData = null
+            effectiveMimeType = null
+        } else {
+            fileData = null
+            effectiveMimeType = null
+            effectiveQuestion = question
+        }
+
+        if (effectiveQuestion != null) {
             chatHistory.update {
                 it.toMutableList().apply {
                     add(
                         History(
                             role = History.Role.USER,
-                            content = question,
+                            content = effectiveQuestion,
                             mimeType = effectiveMimeType,
                             data = fileData,
                         ),

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/composables/QuestionInput.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/composables/QuestionInput.kt
@@ -129,7 +129,7 @@ fun QuestionInput(
 
         val filePickerLauncher = if (allowFileAttachment) {
             rememberFilePickerLauncher(
-                type = FileKitType.ImageAndVideo,
+                type = FileKitType.File(),
             ) { file ->
                 setFile(file)
             }


### PR DESCRIPTION
# Support text file attachments (markdown, txt, json, etc.)

The file picker is locked to `FileKitType.ImageAndVideo`. Android's document picker respects this filter strictly. Text files never appear. Users cannot select `.md`, `.txt`, `.json`, or anything else.

A second bug sits behind the first. `RemoteDataRepository.ask()` runs every file's bytes through `compressImageBytes()` and base64-encodes the output as JPEG. Text content would be destroyed even if it somehow reached this path.

A third gap: no `ACTION_VIEW` intent filter in the manifest. Tapping a `.md` file in a file manager has no way to open Kai.

Reproduced on Samsung S10 (SM-G973F) Android 12. Affects all Android devices.

The picker type in `QuestionInput.kt` changes from `FileKitType.ImageAndVideo` to `FileKitType.File()`. All files now appear.

File handling in `RemoteDataRepository.kt` branches on MIME type. Image and video files follow the existing path: compress, base64-encode, attach via `data` and `mimeType` on `History`. Zero behaviour change for current users. Text files (everything else) are decoded as UTF-8 and prepended to the user's question with a filename header. `data` and `mimeType` stay null. All three API serialisers (Anthropic, Gemini, OpenAI-compatible) see a plain text message. `toAnthropicContentBlocks()`, `toGroqMessageDto()`, and `toGeminiMessageDto()` require no changes.

`AndroidManifest.xml` gains an intent filter for `ACTION_VIEW` and `ACTION_SEND` with MIME types `text/markdown`, `text/x-markdown`, and `text/plain`. The activity does not yet read the incoming `intent.data` URI in `onCreate`/`onNewIntent`. That belongs in a follow-up. The manifest registration is correct regardless, and the in-app picker flow works with this change alone.

Three files changed. 47 insertions, 7 deletions.
