### PR TITLE
feat: add conversation branching (edit to fork)

### DIFF
--- a/composeApp/src/commonMain/composeResources/drawable/ic_edit.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/ic_edit.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="#fff" android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/Conversation.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/Conversation.kt
@@ -23,6 +23,7 @@ data class Conversation(
     val updatedAt: Long,
     val title: String = "",
     val type: String = TYPE_CHAT,
+    val branches: List<BranchData> = emptyList(),
 ) {
     companion object {
         const val TYPE_CHAT = "chat"
@@ -36,13 +37,18 @@ data class Conversation(
         val role: String,
         val content: String,
         val attachments: List<Attachment> = emptyList(),
-        // Legacy single-file fields — retained for reading old persisted conversations.
-        // New code writes only `attachments`; these remain null on newly saved messages.
         val mimeType: String? = null,
         val data: String? = null,
         val fileName: String? = null,
     )
 }
+
+@Serializable
+data class BranchData(
+    val anchorMessageId: String? = null,
+    val branches: List<List<Conversation.Message>>,
+    val activeIndex: Int,
+)
 
 @Serializable
 data class ConversationsData(

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/DataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/DataRepository.kt
@@ -11,6 +11,11 @@ import com.inspiredandroid.kai.ui.settings.SettingsModel
 import io.github.vinceglb.filekit.PlatformFile
 import kotlinx.coroutines.flow.StateFlow
 
+enum class BranchDirection {
+    BACK,
+    FORWARD,
+}
+
 interface DataRepository {
     val chatHistory: StateFlow<List<History>>
     val currentConversationId: StateFlow<String?>
@@ -53,6 +58,11 @@ interface DataRepository {
     fun regenerate()
     fun popLastExchange()
     fun restoreCurrentConversation()
+
+    // Branch management (edit to fork)
+    fun editMessage(messageId: String, newContent: String)
+    fun navigateBranch(messageId: String, direction: BranchDirection)
+    fun getBranchInfo(): Map<String, Pair<Int, Int>>
 
     // Tool management
     fun getToolDefinitions(): List<ToolInfo>

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/RemoteDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/RemoteDataRepository.kt
@@ -1465,23 +1465,12 @@ class RemoteDataRepository(
             id = conversationId,
             messages = history
                 .filter { it.role != History.Role.TOOL_EXECUTING }
-                .map { h ->
-                    Conversation.Message(
-                        id = h.id,
-                        role = when (h.role) {
-                            History.Role.USER -> "user"
-                            History.Role.ASSISTANT -> "assistant"
-                            History.Role.TOOL -> "tool"
-                            History.Role.TOOL_EXECUTING -> "tool" // Should not happen due to filter
-                        },
-                        content = h.content,
-                        attachments = h.attachments,
-                    )
-                },
+                .map { historyToMessage(it) },
             createdAt = existingConversation?.createdAt ?: now,
             updatedAt = now,
             title = title,
             type = existingConversation?.type ?: if (interactiveModeFlag) Conversation.TYPE_INTERACTIVE else Conversation.TYPE_CHAT,
+            branches = serializeBranchGroups(chatHistory.value),
         )
 
         conversationStorage.saveConversation(conversation)
@@ -1491,6 +1480,7 @@ class RemoteDataRepository(
         chatHistory.update {
             emptyList()
         }
+        branchGroups.clear()
     }
 
     override fun isUsingSharedKey(): Boolean = currentService() == Service.Free
@@ -1521,15 +1511,13 @@ class RemoteDataRepository(
         val conversation = savedConversations.value.find { it.id == id } ?: return
 
         setCurrentConversationId(id)
-        chatHistory.value = conversation.messages.map { m ->
-            // Prefer the modern `attachments` field. Fall back to the legacy single-file
-            // fields for conversations saved before multi-attachment support.
+        branchGroups.clear()
+
+        val allHistory = conversation.messages.map { m ->
             val attachments = when {
                 m.attachments.isNotEmpty() -> m.attachments.toImmutableList()
-
                 m.data != null && m.mimeType != null ->
                     persistentListOf(Attachment(data = m.data, mimeType = m.mimeType, fileName = m.fileName))
-
                 else -> persistentListOf()
             }
             History(
@@ -1543,6 +1531,9 @@ class RemoteDataRepository(
                 attachments = attachments,
             )
         }
+
+        chatHistory.value = allHistory.toImmutableList()
+        restoreBranchGroups(conversation.branches)
     }
 
     override suspend fun deleteConversation(id: String) {
@@ -1567,12 +1558,183 @@ class RemoteDataRepository(
     override fun startNewChat() {
         setCurrentConversationId(null)
         chatHistory.value = emptyList()
+        branchGroups.clear()
     }
 
     override fun popLastExchange() {
         chatHistory.update { history ->
             val lastUserIndex = history.indexOfLast { it.role == History.Role.USER }
             if (lastUserIndex >= 0) history.take(lastUserIndex) else history
+        }
+    }
+
+    private data class BranchGroup(
+        val branches: MutableList<List<History>>,
+        var activeIndex: Int,
+    )
+
+    private val branchGroups = mutableMapOf<String?, BranchGroup>()
+
+    private fun findAnchorPosition(anchorId: String?): Int {
+        if (anchorId == null) return 0
+        val history = chatHistory.value
+        val anchorIndex = history.indexOfFirst { it.id == anchorId }
+        return if (anchorIndex >= 0) anchorIndex + 1 else -1
+    }
+
+    private fun saveBranchSuffix(anchorId: String?) {
+        val bg = branchGroups[anchorId] ?: return
+        val position = findAnchorPosition(anchorId)
+        if (position < 0) return
+        val history = chatHistory.value
+        if (position <= history.size && bg.activeIndex < bg.branches.size) {
+            bg.branches[bg.activeIndex] = history.drop(position).toList()
+        }
+    }
+
+    override fun editMessage(messageId: String, newContent: String) {
+        val history = chatHistory.value
+        val index = history.indexOfFirst { it.id == messageId }
+        if (index < 0) return
+        val originalMessage = history[index]
+        if (originalMessage.role != History.Role.USER) return
+
+        val anchorId = if (index > 0) history[index - 1].id else null
+
+        saveBranchSuffix(anchorId)
+
+        val newMessage = originalMessage.copy(
+            id = Uuid.random().toString(),
+            content = newContent,
+        )
+
+        val existing = branchGroups[anchorId]
+        if (existing != null) {
+            existing.branches.add(listOf(newMessage))
+            existing.activeIndex = existing.branches.size - 1
+        } else {
+            val suffix = history.drop(index).toList()
+            branchGroups[anchorId] = BranchGroup(
+                branches = mutableListOf(suffix, listOf(newMessage)),
+                activeIndex = 1,
+            )
+        }
+
+        chatHistory.update { h ->
+            (h.take(index) + newMessage).toImmutableList()
+        }
+    }
+
+    override fun navigateBranch(messageId: String, direction: BranchDirection) {
+        val history = chatHistory.value
+        val index = history.indexOfFirst { it.id == messageId }
+        if (index < 0) return
+
+        val anchorId = if (index > 0) history[index - 1].id else null
+        val bg = branchGroups[anchorId] ?: return
+        if (bg.branches.size <= 1) return
+
+        saveBranchSuffix(anchorId)
+
+        val position = findAnchorPosition(anchorId)
+        if (position < 0) return
+
+        val newIndex = when (direction) {
+            BranchDirection.BACK -> (bg.activeIndex - 1).coerceAtLeast(0)
+            BranchDirection.FORWARD -> (bg.activeIndex + 1).coerceAtMost(bg.branches.size - 1)
+        }
+        if (newIndex == bg.activeIndex) return
+        bg.activeIndex = newIndex
+
+        chatHistory.update { h ->
+            (h.take(position) + bg.branches[newIndex]).toImmutableList()
+        }
+    }
+
+    override fun getBranchInfo(): Map<String, Pair<Int, Int>> {
+        val history = chatHistory.value
+        val result = mutableMapOf<String, Pair<Int, Int>>()
+        for ((anchorId, bg) in branchGroups) {
+            if (bg.branches.size <= 1) continue
+            val position = findAnchorPosition(anchorId)
+            if (position < 0 || position >= history.size) continue
+            result[history[position].id] = bg.activeIndex to bg.branches.size
+        }
+        return result
+    }
+
+    private fun historyToMessage(h: History): Conversation.Message {
+        return Conversation.Message(
+            id = h.id,
+            role = when (h.role) {
+                History.Role.USER -> "user"
+                History.Role.ASSISTANT -> "assistant"
+                History.Role.TOOL -> "tool"
+                History.Role.TOOL_EXECUTING -> "tool"
+            },
+            content = h.content,
+            attachments = h.attachments.toList(),
+        )
+    }
+
+    private fun messageToHistory(m: Conversation.Message): History {
+        val attachments = when {
+            m.attachments.isNotEmpty() -> m.attachments.toImmutableList()
+            m.data != null && m.mimeType != null ->
+                persistentListOf(Attachment(data = m.data, mimeType = m.mimeType, fileName = m.fileName))
+            else -> persistentListOf()
+        }
+        return History(
+            id = m.id,
+            role = when (m.role) {
+                "user" -> History.Role.USER
+                "tool" -> History.Role.TOOL
+                else -> History.Role.ASSISTANT
+            },
+            content = m.content,
+            attachments = attachments,
+        )
+    }
+
+    private fun serializeBranchGroups(currentHistory: List<History>): List<BranchData> {
+        if (branchGroups.isEmpty()) return emptyList()
+        val result = mutableListOf<BranchData>()
+        for ((anchorId, bg) in branchGroups) {
+            if (bg.branches.size <= 1) continue
+            val position = findAnchorPosition(anchorId)
+            if (position < 0) {
+                println("serializeBranchGroups: anchor not found in history, skipping: $anchorId")
+                continue
+            }
+
+            val updatedBranches = bg.branches.toMutableList()
+            if (bg.activeIndex < updatedBranches.size && position <= currentHistory.size) {
+                updatedBranches[bg.activeIndex] = currentHistory
+                    .drop(position)
+                    .filter { it.role != History.Role.TOOL_EXECUTING }
+                    .toList()
+            }
+
+            result.add(BranchData(
+                anchorMessageId = anchorId,
+                branches = updatedBranches.map { branch ->
+                    branch.map { historyToMessage(it) }
+                },
+                activeIndex = bg.activeIndex,
+            ))
+        }
+        return result
+    }
+
+    private fun restoreBranchGroups(branches: List<BranchData>) {
+        branchGroups.clear()
+        for (bd in branches) {
+            branchGroups[bd.anchorMessageId] = BranchGroup(
+                branches = bd.branches.map { branch ->
+                    branch.map { messageToHistory(it) }.toMutableList()
+                }.toMutableList(),
+                activeIndex = bd.activeIndex,
+            )
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatActions.kt
@@ -1,6 +1,7 @@
 package com.inspiredandroid.kai.ui.chat
 
 import androidx.compose.runtime.Immutable
+import com.inspiredandroid.kai.data.BranchDirection
 import io.github.vinceglb.filekit.PlatformFile
 
 @Immutable
@@ -25,4 +26,6 @@ data class ChatActions(
     val enterInteractiveMode: () -> Unit,
     val exitInteractiveMode: () -> Unit,
     val goBackInteractiveMode: () -> Unit,
+    val navigateBranch: (String, BranchDirection) -> Unit,
+    val editMessage: (String, String) -> Unit,
 )

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.draganddrop.dragAndDropTarget
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -56,6 +57,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -77,6 +79,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import com.inspiredandroid.kai.BackIcon
+import com.inspiredandroid.kai.data.BranchDirection
 import com.inspiredandroid.kai.data.Service
 import com.inspiredandroid.kai.getBackgroundDispatcher
 import com.inspiredandroid.kai.onDragAndDropEventDropped
@@ -84,6 +87,7 @@ import com.inspiredandroid.kai.stripMarkdownForTts
 import com.inspiredandroid.kai.ui.chat.composables.BotMessage
 import com.inspiredandroid.kai.ui.chat.composables.ChatHistorySheet
 import com.inspiredandroid.kai.ui.chat.composables.CircleIconButton
+import com.inspiredandroid.kai.ui.chat.composables.EditMessageDialog
 import com.inspiredandroid.kai.ui.chat.composables.EmptyState
 import com.inspiredandroid.kai.ui.chat.composables.ErrorMessage
 import com.inspiredandroid.kai.ui.chat.composables.HeartbeatBanner
@@ -453,6 +457,10 @@ private fun ChatModeScreen(
     navigationTabBar: (@Composable () -> Unit)?,
 ) {
     var showHistorySheet by remember { mutableStateOf(false) }
+    var editingMessageId by remember { mutableStateOf<String?>(null) }
+    val editingMessage = remember(uiState.history, editingMessageId) {
+        uiState.history.find { it.id == editingMessageId }
+    }
     val keyboardController = LocalSoftwareKeyboardController.current
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -617,10 +625,37 @@ private fun ChatModeScreen(
                             ) {
                                 items(uiState.history, key = { it.id }, contentType = { it.role }) { history ->
                                     when (history.role) {
-                                        History.Role.USER -> UserMessage(
-                                            message = history.content,
-                                            attachments = history.attachments,
-                                        )
+                                        History.Role.USER -> {
+                                            UserMessage(
+                                                message = history.content,
+                                                attachments = history.attachments,
+                                                onEdit = if (!uiState.isLoading) { { editingMessageId = history.id } } else null,
+                                            )
+                                            val branch = uiState.branchInfo[history.id]
+                                            if (branch != null && branch.second > 1) {
+                                                Row(
+                                                    modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 4.dp),
+                                                    horizontalArrangement = Arrangement.Start,
+                                                    verticalAlignment = Alignment.CenterVertically,
+                                                ) {
+                                                    TextButton(
+                                                        onClick = { uiState.actions.navigateBranch(history.id, BranchDirection.BACK) },
+                                                        enabled = branch.first > 0,
+                                                        contentPadding = PaddingValues(4.dp),
+                                                    ) { Text("<") }
+                                                    Text(
+                                                        text = "${branch.first + 1} / ${branch.second}",
+                                                        style = MaterialTheme.typography.bodySmall,
+                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    )
+                                                    TextButton(
+                                                        onClick = { uiState.actions.navigateBranch(history.id, BranchDirection.FORWARD) },
+                                                        enabled = branch.first < branch.second - 1,
+                                                        contentPadding = PaddingValues(4.dp),
+                                                    ) { Text(">") }
+                                                }
+                                            }
+                                        }
 
                                         History.Role.ASSISTANT -> {
                                             // Skip thinking messages unless it's the last assistant message
@@ -724,6 +759,17 @@ private fun ChatModeScreen(
         ) { data ->
             Snackbar(snackbarData = data)
         }
+    }
+
+    editingMessage?.let { message ->
+        EditMessageDialog(
+            originalContent = message.content,
+            onDismiss = { editingMessageId = null },
+            onConfirm = { newContent ->
+                uiState.actions.editMessage(message.id, newContent)
+                editingMessageId = null
+            },
+        )
     }
 
     if (showHistorySheet) {

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatUiState.kt
@@ -83,6 +83,7 @@ data class ChatUiState(
     val snackbarMessage: StringResource? = null,
     val pendingConversationDeletion: String? = null,
     val isInteractiveMode: Boolean = false,
+    val branchInfo: Map<String, Pair<Int, Int>> = emptyMap(),
 ) {
     val heartbeatConversationId: String?
         get() = savedConversations.firstOrNull { it.isHeartbeat }?.id

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatViewModel.kt
@@ -2,6 +2,7 @@ package com.inspiredandroid.kai.ui.chat
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.inspiredandroid.kai.data.BranchDirection
 import com.inspiredandroid.kai.data.Conversation
 import com.inspiredandroid.kai.data.DataRepository
 import com.inspiredandroid.kai.data.FreeMode
@@ -61,6 +62,8 @@ class ChatViewModel(
         enterInteractiveMode = ::enterInteractiveMode,
         exitInteractiveMode = ::exitInteractiveMode,
         goBackInteractiveMode = ::goBackInteractiveMode,
+        navigateBranch = ::navigateBranch,
+        editMessage = ::editMessage,
     )
     private val freeModeNames: Map<FreeMode, String> = FreeMode.entries.associateWith { "Free ${it.modelId.replaceFirstChar { c -> c.uppercase() }}" }
     private var currentJob: Job? = null
@@ -114,6 +117,7 @@ class ChatViewModel(
             savedConversations = summaries.toImmutableList(),
             currentConversationId = conversationId,
             hasUnreadHeartbeat = hasUnreadHeartbeat,
+            branchInfo = dataRepository.getBranchInfo(),
         )
     }.distinctUntilChanged().stateIn(
         scope = viewModelScope,
@@ -402,6 +406,15 @@ class ChatViewModel(
         } else {
             dataRepository.popLastExchange()
         }
+    }
+
+    private fun navigateBranch(messageId: String, direction: BranchDirection) {
+        dataRepository.navigateBranch(messageId, direction)
+    }
+
+    private fun editMessage(messageId: String, newContent: String) {
+        dataRepository.editMessage(messageId, newContent)
+        ask(null)
     }
 
     fun refreshSettings() {

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/composables/EditMessageDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/composables/EditMessageDialog.kt
@@ -1,0 +1,64 @@
+package com.inspiredandroid.kai.ui.chat.composables
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EditMessageDialog(
+    originalContent: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var editedContent by remember(originalContent) { mutableStateOf(originalContent) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = "Edit Message")
+        },
+        text = {
+            Column {
+                Text(
+                    text = "This will create a new branch in your conversation.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                TextField(
+                    value = editedContent,
+                    onValueChange = { editedContent = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2,
+                    maxLines = 5,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(editedContent) },
+                enabled = editedContent.isNotBlank() && editedContent != originalContent,
+            ) {
+                Text("Create Branch")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/composables/UserMessage.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/composables/UserMessage.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import com.inspiredandroid.kai.data.Attachment
 import com.inspiredandroid.kai.decodeToImageBitmap
 import kai.composeapp.generated.resources.Res
+import kai.composeapp.generated.resources.ic_edit
 import kai.composeapp.generated.resources.ic_file
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -40,71 +41,83 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 internal fun UserMessage(
     message: String,
     attachments: ImmutableList<Attachment> = persistentListOf(),
+    onEdit: (() -> Unit)? = null,
 ) {
-    SelectionContainer {
-        Row(Modifier.padding(16.dp)) {
-            Spacer(Modifier.weight(1f))
-            Column(
-                modifier = Modifier
-                    .background(
-                        MaterialTheme.colorScheme.onBackground.copy(alpha = 0.15f),
-                        RoundedCornerShape(8.dp),
-                    )
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.End,
-            ) {
-                val images = attachments.filter { it.mimeType.startsWith("image/") }
-                val others = attachments.filter { !it.mimeType.startsWith("image/") }
-                for (att in images) {
-                    val imageBitmap = remember(att.data) {
-                        try {
-                            decodeToImageBitmap(Base64.decode(att.data))
-                        } catch (_: Exception) {
-                            null
+    Column(horizontalAlignment = Alignment.End) {
+        SelectionContainer {
+            Row(Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp)) {
+                Spacer(Modifier.weight(1f))
+                Column(
+                    modifier = Modifier
+                        .background(
+                            MaterialTheme.colorScheme.onBackground.copy(alpha = 0.15f),
+                            RoundedCornerShape(8.dp),
+                        )
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.End,
+                ) {
+                    val images = attachments.filter { it.mimeType.startsWith("image/") }
+                    val others = attachments.filter { !it.mimeType.startsWith("image/") }
+                    for (att in images) {
+                        val imageBitmap = remember(att.data) {
+                            try {
+                                decodeToImageBitmap(Base64.decode(att.data))
+                            } catch (_: Exception) {
+                                null
+                            }
+                        }
+                        if (imageBitmap != null) {
+                            Image(
+                                bitmap = imageBitmap,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .widthIn(max = 200.dp)
+                                    .clip(RoundedCornerShape(8.dp)),
+                                contentScale = ContentScale.FillWidth,
+                            )
+                            Spacer(Modifier.height(8.dp))
                         }
                     }
-                    if (imageBitmap != null) {
-                        Image(
-                            bitmap = imageBitmap,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .widthIn(max = 200.dp)
-                                .clip(RoundedCornerShape(8.dp)),
-                            contentScale = ContentScale.FillWidth,
-                        )
-                        Spacer(Modifier.height(8.dp))
-                    }
-                }
-                if (others.isNotEmpty()) {
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp),
-                    ) {
-                        for (att in others) {
-                            SuggestionChip(
-                                onClick = {},
-                                icon = {
-                                    Icon(
-                                        modifier = Modifier.size(16.dp),
-                                        painter = painterResource(Res.drawable.ic_file),
-                                        contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.onBackground,
-                                    )
-                                },
-                                label = { Text(truncateFileName(att.fileName ?: att.mimeType)) },
-                            )
+                    if (others.isNotEmpty()) {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            for (att in others) {
+                                SuggestionChip(
+                                    onClick = {},
+                                    icon = {
+                                        Icon(
+                                            modifier = Modifier.size(16.dp),
+                                            painter = painterResource(Res.drawable.ic_file),
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.onBackground,
+                                        )
+                                    },
+                                    label = { Text(truncateFileName(att.fileName ?: att.mimeType)) },
+                                )
+                            }
+                        }
+                        if (message.isNotEmpty()) {
+                            Spacer(Modifier.height(8.dp))
                         }
                     }
                     if (message.isNotEmpty()) {
-                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = message,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
                     }
                 }
-                if (message.isNotEmpty()) {
-                    Text(
-                        text = message,
-                        color = MaterialTheme.colorScheme.onBackground,
-                    )
-                }
+            }
+        }
+        if (onEdit != null) {
+            Row(Modifier.padding(horizontal = 8.dp)) {
+                SmallIconButton(
+                    iconResource = Res.drawable.ic_edit,
+                    contentDescription = "Edit",
+                    onClick = onEdit,
+                )
             }
         }
     }

--- a/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/testutil/FakeDataRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/testutil/FakeDataRepository.kt
@@ -1,5 +1,6 @@
 package com.inspiredandroid.kai.testutil
 
+import com.inspiredandroid.kai.data.BranchDirection
 import com.inspiredandroid.kai.data.Conversation
 import com.inspiredandroid.kai.data.DataRepository
 import com.inspiredandroid.kai.data.EmailAccount
@@ -263,6 +264,16 @@ class FakeDataRepository : DataRepository {
     override fun restoreCurrentConversation() {
         // No-op in tests
     }
+
+    override fun editMessage(messageId: String, newContent: String) {
+        // No-op in tests
+    }
+
+    override fun navigateBranch(messageId: String, direction: BranchDirection) {
+        // No-op in tests
+    }
+
+    override fun getBranchInfo(): Map<String, Pair<Int, Int>> = emptyMap()
 
     override fun getToolDefinitions(): List<ToolInfo> = CommonTools.commonToolDefinitions
 

--- a/screenshotTests/src/test/kotlin/com/inspiredandroid/kai/screenshots/ScreenshotTestData.kt
+++ b/screenshotTests/src/test/kotlin/com/inspiredandroid/kai/screenshots/ScreenshotTestData.kt
@@ -45,6 +45,8 @@ object ScreenshotTestData {
         enterInteractiveMode = { },
         exitInteractiveMode = { },
         goBackInteractiveMode = { },
+        navigateBranch = { _, _ -> },
+        editMessage = { _, _ -> },
     )
 
     val chatEmptyState = ChatUiState(


### PR DESCRIPTION
## Why

Sometimes, I want to go back and edit a message, but it's also nice to have forks of conversations. This is a common feature from most AI Chats, so it feels a welcome addition to Kai.

## What

- **Edit icon** below user messages opens an edit dialog
- Editing creates a **branch** — the original conversation path is preserved
- Edited messages **automatically trigger an AI response**
- Inline **`< X / Y >`** navigation between branches (below the branched message)
- **Multiple branch groups** supported at different fork points in the same conversation
- Branches are **persisted** to conversation JSON — survive app restart and conversation switching
- Edit icon **disabled during loading** to prevent conflicts
- Backward compatible — old conversations without branch data load normally

## Files Changed

- `Conversation.kt` — Added `BranchData` for branch persistence
- `DataRepository.kt` — Added `BranchDirection` enum and interface methods
- `RemoteDataRepository.kt` — Branch group management, serialization/deserialization
- `ChatUiState.kt` — Added `branchInfo` to state
- `ChatViewModel.kt` — `editMessage` calls `ask(null)` for auto-response
- `ChatScreen.kt` — Inline branch navigation below user messages
- `UserMessage.kt` — Added edit icon button (same pattern as bot message icons)
- `EditMessageDialog.kt` — New composable for editing messages
- `ic_edit.xml` — New edit icon drawable
- `ChatActions.kt` — Added `navigateBranch` and `editMessage`
- `FakeDataRepository.kt`, `ScreenshotTestData.kt` — Test stubs

## Tested

- Desktop build passes (`compileKotlinDesktop`)
- App launches without crashes
- Backward compatible with existing conversations