### PR TITLE
Add Z.AI Coding Plan service

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/Service.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/Service.kt
@@ -319,6 +319,19 @@ sealed class Service(
         apiKeyUrlDisplay = "z.ai/manage-apikey/apikey-list",
     )
 
+    data object ZaiCodingPlan : Service(
+        id = "zai-coding-plan",
+        displayName = "Z.AI Coding Plan",
+        icon = Res.drawable.ic_service_zai,
+        requiresApiKey = true,
+        defaultModel = null,
+        settingsKeyPrefix = "zai-coding-plan",
+        chatUrl = "https://api.z.ai/api/coding/paas/v4/chat/completions",
+        modelsUrl = "https://api.z.ai/api/coding/paas/v4/models",
+        apiKeyUrl = "https://z.ai/manage-apikey/apikey-list",
+        apiKeyUrlDisplay = "z.ai/manage-apikey/apikey-list",
+    )
+
     data object Minimax : Service(
         id = "minimax",
         displayName = "MiniMax",
@@ -421,7 +434,7 @@ sealed class Service(
     )
 
     companion object {
-        val all: List<Service> get() = listOf(Free, Gemini, Anthropic, OpenAI, DeepSeek, Mistral, XAI, OpenRouter, Groq, Nvidia, Cerebras, OllamaCloud, LongCat, Together, HuggingFace, Venice, Moonshot, Zai, Minimax, AiHubMix, DeepInfra, FireworksAI, OpenCode, PublicAI, OpenAICompatible, LiteRT)
+        val all: List<Service> get() = listOf(Free, Gemini, Anthropic, OpenAI, DeepSeek, Mistral, XAI, OpenRouter, Groq, Nvidia, Cerebras, OllamaCloud, LongCat, Together, HuggingFace, Venice, Moonshot, Zai, ZaiCodingPlan, Minimax, AiHubMix, DeepInfra, FireworksAI, OpenCode, PublicAI, OpenAICompatible, LiteRT)
 
         const val DEFAULT_OPENAI_COMPATIBLE_BASE_URL = "http://localhost:11434/v1"
 


### PR DESCRIPTION
## Summary

Add a new **Z.AI Coding Plan** service that uses the dedicated Coding API endpoint (`https://api.z.ai/api/coding/paas/v4`) instead of the general API endpoint (`https://api.z.ai/api/paas/v4`).

## Problem

Z.AI Coding Plan subscribers (Lite/Pro/Max plans) **must** use a separate API base URL. When using the general API endpoint with a Coding Plan API key, Z.AI returns HTTP 429 with body `"Insufficient balance or no resource package. Please recharge."` — even on the very first request.

This gets surfaced in Kai as "Rate limit exceeded", which is misleading. The real issue is that the Coding Plan subscription only covers the `/api/coding/paas/v4/` endpoint, not `/api/paas/v4/`.

Reference: [Z.AI Quick Start docs](https://docs.z.ai/devpack/quick-start) explicitly state:
> *"Using the GLM Coding Plan, you need to configure the dedicated Coding API `https://api.z.ai/api/coding/paas/v4` instead of the General API `https://api.z.ai/api/paas/v4`"*

## Changes

- **`Service.kt`**: Add `ZaiCodingPlan` data object with Coding Plan API URLs, placed after the existing `Zai` service
- **`Service.kt`**: Register `ZaiCodingPlan` in the `all` services list
- Reuses the existing Z.AI icon and API key management URL
- Separate `settingsKeyPrefix` (`zai-coding-plan`) so settings don't collide with the regular Z.AI service

## Testing

Verified via curl that the Coding Plan endpoint works with standard model IDs (e.g. `glm-4.7`, `glm-5.1`) while the general endpoint returns 429 for Coding Plan subscribers.