### PR TITLE
fix: add missing @OptIn(ExperimentalNativeApi) for MutableList.replaceAll in test

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/ui/sandbox/SandboxFileBrowserViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/ui/sandbox/SandboxFileBrowserViewModelTest.kt
@@ -76,6 +76,7 @@ class SandboxFileBrowserViewModelTest {
             return deleteResult
         }
 
+        @OptIn(kotlin.experimental.ExperimentalNativeApi::class)
         override suspend fun renameEntry(path: String, newName: String): Result<String> {
             lastRenameCall = path to newName
             val override = renameResult


### PR DESCRIPTION
## Summary

- Fixes iOS test compilation (`compileTestKotlinIosArm64`) by adding the missing `@OptIn(kotlin.experimental.ExperimentalNativeApi::class)` annotation
- `MutableList.replaceAll` requires opt-in on native targets, which broke after the rebrand/privacy-cleanup changes
- Applies the fix in `SandboxFileBrowserViewModelTest.kt`