### PR TITLE
Add real-time SSE streaming for LLM chat responses

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/RemoteDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/RemoteDataRepository.kt
@@ -30,6 +30,8 @@ import com.inspiredandroid.kai.network.OpenAICompatibleEmptyResponseException
 import com.inspiredandroid.kai.network.OpenAICompatibleQuotaExhaustedException
 import com.inspiredandroid.kai.network.Requests
 import com.inspiredandroid.kai.network.ServiceCredentials
+import com.inspiredandroid.kai.network.StreamAccumulator
+import com.inspiredandroid.kai.network.StreamEvent
 import com.inspiredandroid.kai.network.UnsupportedFileTypeException
 import com.inspiredandroid.kai.network.dtos.anthropic.extractText
 import com.inspiredandroid.kai.network.dtos.gemini.extractText
@@ -130,6 +132,8 @@ private data class LoopChatResult(
 private data class AssistantTurn(
     val content: String,
     val reasoningContent: String? = null,
+    /** True when the turn was streamed and already added to [chatHistory]. */
+    val alreadyInHistory: Boolean = false,
 )
 
 private enum class BailoutReason { LIMIT_REACHED, REPEATING }
@@ -138,6 +142,24 @@ private interface ToolLoopStrategy {
     suspend fun chat(history: List<History>, systemPrompt: String?): LoopChatResult
     suspend fun bailout(history: List<History>, systemPrompt: String?, reason: BailoutReason): String
     fun trimAfterToolResults(history: List<History>, systemPrompt: String?): List<History> = history
+
+    /**
+     * Streaming variant of [chat]. The default implementation delegates to the
+     * batch [chat] and calls [onToken] once with the full text at completion.
+     * Providers that support SSE streaming override this to deliver tokens
+     * incrementally.
+     */
+    suspend fun streamingChat(
+        history: List<History>,
+        systemPrompt: String?,
+        onToken: suspend (String) -> Unit,
+    ): LoopChatResult {
+        val result = chat(history, systemPrompt)
+        if (result.textContent.isNotEmpty()) {
+            onToken(result.textContent)
+        }
+        return result
+    }
 }
 
 class RemoteDataRepository(
@@ -831,16 +853,31 @@ class RemoteDataRepository(
                 if (index > 0) {
                     fallbackServiceName = entry.service.displayName
                 }
-                chatHistory.update {
-                    it.toMutableList().apply {
-                        add(
-                            History(
-                                role = History.Role.ASSISTANT,
-                                content = turn.content,
-                                reasoningContent = turn.reasoningContent,
-                                fallbackServiceName = fallbackServiceName,
-                            ),
-                        )
+                // When the response was streamed, the assistant entry was already
+                // added to chatHistory by runToolLoop — just finalize it with the
+                // fallback tag. Otherwise, add the full entry now.
+                if (turn.alreadyInHistory) {
+                    if (fallbackServiceName != null) {
+                        chatHistory.update { h ->
+                            h.mapIndexed { i, entry ->
+                                if (i == h.lastIndex && entry.role == History.Role.ASSISTANT) {
+                                    entry.copy(fallbackServiceName = fallbackServiceName)
+                                } else entry
+                            }
+                        }
+                    }
+                } else {
+                    chatHistory.update {
+                        it.toMutableList().apply {
+                            add(
+                                History(
+                                    role = History.Role.ASSISTANT,
+                                    content = turn.content,
+                                    reasoningContent = turn.reasoningContent,
+                                    fallbackServiceName = fallbackServiceName,
+                                ),
+                            )
+                        }
                     }
                 }
                 saveCurrentConversation()
@@ -903,6 +940,51 @@ class RemoteDataRepository(
                 // Bailout sends no tools — strip historic tool_calls to satisfy strict validators.
                 val msgs = trimMessagesForContext(buildOpenAIMessages(service, history, systemPrompt, declaredToolNames = emptySet()), contextWindowTokens)
                 return makeFinalCallWithoutTools(service, credentials, msgs)
+            }
+
+            override suspend fun streamingChat(
+                history: List<History>,
+                systemPrompt: String?,
+                onToken: suspend (String) -> Unit,
+            ): LoopChatResult {
+                val acc = StreamAccumulator()
+                val msgs = trimMessagesForContext(buildOpenAIMessages(service, history, systemPrompt, declaredToolNames), contextWindowTokens)
+                try {
+                    requests.streamingOpenAICompatibleChat(
+                        service = service,
+                        credentials = credentials,
+                        messages = msgs,
+                        tools = tools,
+                    ) { event ->
+                        when (event) {
+                            is StreamEvent.Token -> {
+                                acc.appendToken(event.text)
+                                onToken(event.text)
+                            }
+                            is StreamEvent.ToolCalls -> acc.appendToolCalls(event.calls)
+                            is StreamEvent.Finished -> {} // no-op; accumulator has the data
+                            is StreamEvent.Error -> throw event.throwable
+                        }
+                    }
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    // Fall back to batch on streaming failure
+                    return chat(history, systemPrompt)
+                }
+                val result = acc.build()
+                // Inline tool calls extraction (mirrors batch chat path)
+                var textContent = result.text
+                var calls = result.toolCalls
+                if (calls.isEmpty() && textContent.contains("<tool_call>")) {
+                    val extracted = extractInlineToolCalls(textContent, tools)
+                    if (extracted.calls.isNotEmpty()) {
+                        textContent = extracted.cleanedText
+                        calls = extracted.calls.map {
+                            ToolCallInfo(id = "inline-${Uuid.random()}", name = it.name, arguments = it.arguments)
+                        }
+                    }
+                }
+                return LoopChatResult(textContent = textContent, toolCalls = calls)
             }
         }
         return runToolLoop(strategy, systemPrompt, history)
@@ -1011,6 +1093,38 @@ class RemoteDataRepository(
                 return bailoutResponse.extractText()
             }
 
+            override suspend fun streamingChat(
+                history: List<History>,
+                systemPrompt: String?,
+                onToken: suspend (String) -> Unit,
+            ): LoopChatResult {
+                val acc = StreamAccumulator()
+                try {
+                    requests.streamingAnthropicChat(
+                        credentials = credentials,
+                        messages = buildAnthropicMessages(history),
+                        tools = tools,
+                        systemInstruction = systemPrompt,
+                    ) { event ->
+                        when (event) {
+                            is StreamEvent.Token -> {
+                                acc.appendToken(event.text)
+                                onToken(event.text)
+                            }
+                            is StreamEvent.ToolCalls -> acc.appendToolCalls(event.calls)
+                            is StreamEvent.Finished -> {} // no-op; accumulator has the data
+                            is StreamEvent.Error -> throw event.throwable
+                        }
+                    }
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    // Fall back to batch on streaming failure
+                    return chat(history, systemPrompt)
+                }
+                val result = acc.build()
+                return LoopChatResult(textContent = result.text, toolCalls = result.toolCalls)
+            }
+
             override fun trimAfterToolResults(history: List<History>, systemPrompt: String?): List<History> = trimHistoryForContext(history, systemPrompt?.length ?: 0, contextWindowTokens)
         }
         return runToolLoop(strategy, systemPrompt, history)
@@ -1029,22 +1143,66 @@ class RemoteDataRepository(
             if (iteration > MAX_TOOL_ITERATIONS) {
                 return AssistantTurn(strategy.bailout(visible, systemPrompt, BailoutReason.LIMIT_REACHED))
             }
-            val result = strategy.chat(visible, systemPrompt)
-            if (result.toolCalls.isEmpty()) {
-                // For thinking-only turns, the reasoning text already became the content via
-                // `isContentFromReasoning`, so don't surface it again as a reasoning trace.
-                val reasoning = result.reasoningContent?.takeIf { !result.isThinkingContent }
-                return AssistantTurn(result.textContent, reasoning)
+
+            // Create a placeholder assistant entry that will be updated in real-time
+            // as tokens arrive from the streaming API. For providers that don't
+            // override streamingChat, the placeholder is updated once with the full
+            // response when the batch call completes.
+            val placeholderId = Uuid.random().toString()
+            history.update {
+                it.toMutableList().apply {
+                    add(History(id = placeholderId, role = History.Role.ASSISTANT, content = ""))
+                }
             }
 
+            val result = strategy.streamingChat(
+                history = visible,
+                systemPrompt = systemPrompt,
+            ) { token ->
+                // Update the placeholder content with each incoming token so the
+                // UI renders the response as it is generated.
+                history.update { h ->
+                    h.map { entry ->
+                        if (entry.id == placeholderId) {
+                            entry.copy(content = entry.content + token)
+                        } else {
+                            entry
+                        }
+                    }
+                }
+            }
+
+            if (result.toolCalls.isEmpty()) {
+                // Final answer — placeholder already has the streamed content.
+                // Update reasoning/isThinking metadata on the placeholder and
+                // signal that askInternal should not add a duplicate entry.
+                history.update { h ->
+                    h.map { entry ->
+                        if (entry.id == placeholderId) {
+                            entry.copy(
+                                isThinking = result.isThinkingContent,
+                                reasoningContent = result.reasoningContent,
+                            )
+                        } else {
+                            entry
+                        }
+                    }
+                }
+                val reasoning = result.reasoningContent?.takeIf { !result.isThinkingContent }
+                return AssistantTurn(result.textContent, reasoning, alreadyInHistory = true)
+            }
+
+            // Tool calls: remove the streaming placeholder and replace with the
+            // proper assistant entry carrying tool-call metadata.
             val signatures = result.toolCalls.map { "${it.name}:${it.arguments.hashCode()}" }
             if (isRepeatingToolCalls(recentSignatures, signatures)) {
+                history.update { h -> h.filter { it.id != placeholderId } }
                 return AssistantTurn(strategy.bailout(visible, systemPrompt, BailoutReason.REPEATING))
             }
             recentSignatures.addAll(signatures)
 
-            history.update {
-                it.toMutableList().apply {
+            history.update { h ->
+                h.filter { it.id != placeholderId }.toMutableList().apply {
                     add(
                         History(
                             role = History.Role.ASSISTANT,

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/AnthropicStreamParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/AnthropicStreamParser.kt
@@ -1,0 +1,119 @@
+package com.inspiredandroid.kai.network
+
+import com.inspiredandroid.kai.ui.chat.ToolCallInfo
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Parses Anthropic SSE streaming events into [StreamEvent]s.
+ *
+ * Anthropic uses typed SSE events:
+ *   event: message_start      — stream metadata
+ *   event: content_block_start — new content block (text or tool_use)
+ *   event: content_block_delta — incremental content
+ *   event: content_block_stop  — content block complete
+ *   event: message_delta       — stop_reason, usage
+ *   event: message_stop        — stream end
+ *
+ * Text deltas:  delta.type = "text_delta", delta.text = "..."
+ * Tool deltas:  delta.type = "input_json_delta", delta.partial_json = "..."
+ */
+class AnthropicStreamParser(
+    private val onEvent: suspend (StreamEvent) -> Unit,
+) {
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    // Accumulate tool-use arguments per content block index.
+    private data class ToolUseBuf(
+        var id: String? = null,
+        var name: String? = null,
+        val arguments: StringBuilder = StringBuilder(),
+    )
+
+    private val toolUseBufs = mutableMapOf<Int, ToolUseBuf>()
+
+    /** Process one SSE event. */
+    suspend fun onEvent(event: String?, data: String) {
+        try {
+            when (event) {
+                "content_block_start" -> handleContentBlockStart(data)
+                "content_block_delta" -> handleContentBlockDelta(data)
+                "content_block_stop" -> {} // no-op; tool use accumulates across deltas
+                "message_delta" -> handleMessageDelta(data)
+                "message_stop" -> {
+                    flushToolUses()
+                    onEvent(StreamEvent.Finished(null))
+                }
+                "ping" -> {} // keepalive
+                // message_start, error are handled as needed
+            }
+        } catch (_: Exception) {
+            // Malformed event — skip
+        }
+    }
+
+    private suspend fun handleContentBlockStart(data: String) {
+        val obj = json.parseToJsonElement(data).jsonObject
+        val contentBlock = obj["content_block"]?.jsonObject ?: return
+        val type = contentBlock["type"]?.jsonPrimitive?.content ?: return
+        val index = obj["index"]?.jsonPrimitive?.int ?: return
+
+        when (type) {
+            "text" -> {} // Text block will receive text_delta events
+            "tool_use" -> {
+                val buf = ToolUseBuf()
+                buf.id = contentBlock["id"]?.jsonPrimitive?.content
+                buf.name = contentBlock["name"]?.jsonPrimitive?.content
+                toolUseBufs[index] = buf
+            }
+        }
+    }
+
+    private suspend fun handleContentBlockDelta(data: String) {
+        val obj = json.parseToJsonElement(data).jsonObject
+        val delta = obj["delta"]?.jsonObject ?: return
+        val type = delta["type"]?.jsonPrimitive?.content ?: return
+        val index = obj["index"]?.jsonPrimitive?.int ?: return
+
+        when (type) {
+            "text_delta" -> {
+                val text = delta["text"]?.jsonPrimitive?.content ?: return
+                onEvent(StreamEvent.Token(text))
+            }
+            "input_json_delta" -> {
+                val partialJson = delta["partial_json"]?.jsonPrimitive?.content ?: return
+                toolUseBufs[index]?.arguments?.append(partialJson)
+            }
+        }
+    }
+
+    private fun handleMessageDelta(data: String) {
+        // Extract stop_reason if present
+        val obj = json.parseToJsonElement(data).jsonObject
+        val delta = obj["delta"]?.jsonObject
+        val stopReason = delta?.get("stop_reason")?.jsonPrimitive?.content
+        // stop_reason is noted in StreamEvent.Finished in message_stop handler
+    }
+
+    private suspend fun flushToolUses() {
+        if (toolUseBufs.isEmpty()) return
+        val calls = toolUseBufs.values.mapNotNull { buf ->
+            val name = buf.name ?: return@mapNotNull null
+            ToolCallInfo(
+                id = buf.id ?: "anthropic-${name.hashCode()}",
+                name = name,
+                arguments = buf.arguments.toString().ifEmpty { "{}" },
+            )
+        }
+        toolUseBufs.clear()
+        if (calls.isNotEmpty()) {
+            onEvent(StreamEvent.ToolCalls(calls))
+        }
+    }
+
+    fun reset() {
+        toolUseBufs.clear()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/OpenAICompatibleStreamParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/OpenAICompatibleStreamParser.kt
@@ -1,0 +1,104 @@
+package com.inspiredandroid.kai.network
+
+import com.inspiredandroid.kai.ui.chat.ToolCallInfo
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Parses OpenAI-compatible SSE streaming chunks into [StreamEvent]s.
+ *
+ * Each chunk is a JSON line with:
+ *   {"choices":[{"index":0,"delta":{"content":"..."},"finish_reason":null}]}
+ *
+ * Tool calls arrive as incremental deltas:
+ *   delta.tool_calls[0] = {index:0, id:"...", function:{name:"...", arguments:"..."}}
+ *
+ * The stream terminates with a "data: [DONE]" sentinel.
+ */
+class OpenAICompatibleStreamParser(
+    private val onEvent: suspend (StreamEvent) -> Unit,
+) {
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    // Track in-progress tool calls by index so we can accumulate delta fragments.
+    private data class ToolCallBuf(
+        var id: String? = null,
+        var name: String? = null,
+        val arguments: StringBuilder = StringBuilder(),
+    )
+
+    private val toolCallBufs = mutableMapOf<Int, ToolCallBuf>()
+
+    /** Process one SSE data payload. */
+    suspend fun onData(data: String) {
+        if (data == "[DONE]") {
+            flushToolCalls()
+            onEvent(StreamEvent.Finished(null))
+            return
+        }
+
+        val chunk = try {
+            json.parseToJsonElement(data).jsonObject
+        } catch (_: Exception) {
+            return
+        }
+
+        val choices = chunk["choices"]?.jsonArray ?: return
+        for (choice in choices) {
+            val obj = choice.jsonObject
+            val delta = obj["delta"]?.jsonObject ?: continue
+            val finishReason = obj["finish_reason"]?.jsonPrimitive?.content
+
+            // Text content
+            val content = delta["content"]?.jsonPrimitive?.content
+            if (!content.isNullOrEmpty()) {
+                onEvent(StreamEvent.Token(content))
+            }
+
+            // Tool calls (incremental)
+            val toolCalls = delta["tool_calls"]?.jsonArray
+            if (toolCalls != null) {
+                for (tc in toolCalls) {
+                    val tcObj = tc.jsonObject
+                    val index = tcObj["index"]?.jsonPrimitive?.int ?: continue
+                    val buf = toolCallBufs.getOrPut(index) { ToolCallBuf() }
+
+                    tcObj["id"]?.jsonPrimitive?.content?.let { buf.id = it }
+                    val fn = tcObj["function"]?.jsonObject
+                    fn?.get("name")?.jsonPrimitive?.content?.let { buf.name = it }
+                    fn?.get("arguments")?.jsonPrimitive?.content?.let { buf.arguments.append(it) }
+                }
+            }
+
+            // If finish_reason is set and we have tool calls, flush them
+            if (!finishReason.isNullOrEmpty() && finishReason != "stop") {
+                flushToolCalls()
+            }
+        }
+    }
+
+    private suspend fun flushToolCalls() {
+        if (toolCallBufs.isEmpty()) return
+        val calls = toolCallBufs.values.mapNotNull { buf ->
+            val name = buf.name ?: return@mapNotNull null
+            ToolCallInfo(
+                id = buf.id ?: "stream-${name.hashCode()}",
+                name = name,
+                arguments = buf.arguments.toString(),
+            )
+        }
+        toolCallBufs.clear()
+        if (calls.isNotEmpty()) {
+            onEvent(StreamEvent.ToolCalls(calls))
+        }
+    }
+
+    /** Reset state for a new stream. */
+    fun reset() {
+        toolCallBufs.clear()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/Requests.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/Requests.kt
@@ -32,8 +32,10 @@ import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
+import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
@@ -219,6 +221,55 @@ class Requests {
         Result.failure(mapOpenAICompatibleException(e))
     }
 
+    /**
+     * Streaming variant of [openAICompatibleChat]. Sends `stream: true` and reads
+     * the SSE response incrementally, calling [onEvent] for each token / tool-call /
+     * completion event. The call suspends until the stream ends or an error occurs.
+     */
+    suspend fun streamingOpenAICompatibleChat(
+        service: Service,
+        credentials: ServiceCredentials,
+        messages: List<OpenAICompatibleChatRequestDto.Message>,
+        tools: List<Tool> = emptyList(),
+        customHeaders: Map<String, String> = emptyMap(),
+        onEvent: suspend (StreamEvent) -> Unit,
+    ) {
+        val apiKey = getApiKeyOrThrow(service, credentials)
+        val model = credentials.modelId.ifEmpty { null }
+        val url = resolveUrl(service, credentials, service.chatUrl)
+
+        try {
+            defaultClient.preparePost(url) {
+                contentType(ContentType.Application.Json)
+                apiKey?.let { bearerAuth(it) }
+                customHeaders.forEach { (k, v) -> header(k, v) }
+                setBody(
+                    OpenAICompatibleChatRequestDto(
+                        messages = messages,
+                        model = model,
+                        tools = tools.mapNotNull { runCatching { it.toRequestTool() }.getOrNull() }
+                            .ifEmpty { null },
+                        stream = true,
+                    ),
+                )
+            }.execute { response ->
+                if (!response.status.isSuccess()) {
+                    handleOpenAICompatibleError(service, credentials, response)
+                }
+                val parser = OpenAICompatibleStreamParser(onEvent)
+                SseParser(response.bodyAsChannel()) { _, data ->
+                    parser.onData(data)
+                }.parse()
+            }
+        } catch (e: OpenAICompatibleApiException) {
+            onEvent(StreamEvent.Error(e))
+        } catch (e: io.ktor.client.plugins.HttpRequestTimeoutException) {
+            onEvent(StreamEvent.Error(OpenAICompatibleConnectionException()))
+        } catch (e: Exception) {
+            onEvent(StreamEvent.Error(mapOpenAICompatibleException(e)))
+        }
+    }
+
     suspend fun getOpenAICompatibleModels(
         service: Service,
         credentials: ServiceCredentials,
@@ -335,6 +386,53 @@ class Requests {
         Result.failure(e)
     } catch (e: Exception) {
         Result.failure(AnthropicGenericException("Anthropic: ${e.message}", e))
+    }
+
+    /**
+     * Streaming variant of [anthropicChat]. Sends `stream: true` and reads the SSE
+     * response incrementally, calling [onEvent] for each token / tool-call /
+     * completion event. The call suspends until the stream ends or an error occurs.
+     */
+    suspend fun streamingAnthropicChat(
+        credentials: ServiceCredentials,
+        messages: List<AnthropicChatRequestDto.Message>,
+        tools: List<Tool> = emptyList(),
+        systemInstruction: String? = null,
+        onEvent: suspend (StreamEvent) -> Unit,
+    ) {
+        val apiKey = credentials.apiKey.ifEmpty { throw AnthropicInvalidApiKeyException() }
+
+        try {
+            defaultClient.preparePost(Service.Anthropic.chatUrl) {
+                contentType(ContentType.Application.Json)
+                header("x-api-key", apiKey)
+                header("anthropic-version", "2023-06-01")
+                setBody(
+                    AnthropicChatRequestDto(
+                        model = credentials.modelId,
+                        messages = messages,
+                        max_tokens = 8192,
+                        system = systemInstruction,
+                        tools = tools.mapNotNull { runCatching { it.toAnthropicTool() }.getOrNull() }
+                            .ifEmpty { null },
+                        stream = true,
+                    ),
+                )
+            }.execute { response ->
+                if (!response.status.isSuccess()) {
+                    val responseBody = response.bodyAsText()
+                    throwAnthropicError(response.status.value, responseBody)
+                }
+                val parser = AnthropicStreamParser(onEvent)
+                SseParser(response.bodyAsChannel()) { event, data ->
+                    parser.onEvent(event, data)
+                }.parse()
+            }
+        } catch (e: AnthropicApiException) {
+            onEvent(StreamEvent.Error(e))
+        } catch (e: Exception) {
+            onEvent(StreamEvent.Error(AnthropicGenericException("Anthropic: ${e.message}", e)))
+        }
     }
 
     private fun throwAnthropicError(statusCode: Int, responseBody: String): Nothing {

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/SseParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/SseParser.kt
@@ -1,0 +1,56 @@
+package com.inspiredandroid.kai.network
+
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readUTF8Line
+
+/**
+ * Minimal SSE (Server-Sent Events) parser that reads lines from a
+ * [ByteReadChannel] and invokes [onEvent] for each complete event.
+ *
+ * Handles the "data:" and "event:" fields. Multi-line data fields
+ * are joined with newlines before dispatch.
+ */
+class SseParser(
+    private val channel: ByteReadChannel,
+    private val onEvent: suspend (event: String?, data: String) -> Unit,
+) {
+    private var currentEvent: String? = null
+    private var dataBuffer = StringBuilder()
+
+    /** Read the channel to exhaustion, dispatching events as they arrive. */
+    suspend fun parse() {
+        try {
+            while (!channel.isClosedForRead) {
+                val line = channel.readUTF8Line() ?: break
+                if (line.isEmpty()) {
+                    // Empty line = event boundary
+                    dispatch()
+                } else if (line.startsWith(":")) {
+                    // Comment — skip (used as keepalive by some providers)
+                    continue
+                } else if (line.startsWith("event:")) {
+                    currentEvent = line.removePrefix("event:").trim()
+                } else if (line.startsWith("data:")) {
+                    val payload = line.removePrefix("data:").trim()
+                    if (dataBuffer.isNotEmpty()) dataBuffer.append('\n')
+                    dataBuffer.append(payload)
+                }
+                // Ignore other fields (id:, retry:, etc.)
+            }
+            // Flush any remaining event (connection closed without trailing blank line)
+            dispatch()
+        } catch (_: Exception) {
+            // Channel closed or read interrupted — dispatch whatever we have
+            dispatch()
+        }
+    }
+
+    private suspend fun dispatch() {
+        val data = dataBuffer.toString()
+        dataBuffer = StringBuilder()
+        if (data.isNotEmpty()) {
+            onEvent(currentEvent, data)
+        }
+        currentEvent = null
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/StreamEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/StreamEvent.kt
@@ -1,0 +1,45 @@
+package com.inspiredandroid.kai.network
+
+import com.inspiredandroid.kai.ui.chat.ToolCallInfo
+
+/**
+ * Events emitted during a streaming chat completion. The caller drives the
+ * stream by collecting these events and updating the UI incrementally.
+ */
+sealed class StreamEvent {
+    /** A text token from the assistant. */
+    data class Token(val text: String) : StreamEvent()
+
+    /** A completed tool call extracted from the stream. */
+    data class ToolCalls(val calls: List<ToolCallInfo>) : StreamEvent()
+
+    /** The stream completed successfully with the given stop reason. */
+    data class Finished(val stopReason: String? = null) : StreamEvent()
+
+    /** The stream terminated with an error. */
+    data class Error(val throwable: Throwable) : StreamEvent()
+}
+
+/** Accumulates streaming state into a completed [StreamResult]. */
+class StreamAccumulator {
+    val textBuilder = StringBuilder()
+    val toolCalls = mutableListOf<ToolCallInfo>()
+
+    fun appendToken(text: String) {
+        textBuilder.append(text)
+    }
+
+    fun appendToolCalls(calls: List<ToolCallInfo>) {
+        toolCalls.addAll(calls)
+    }
+
+    fun build(): StreamResult = StreamResult(
+        text = textBuilder.toString(),
+        toolCalls = toolCalls.toList(),
+    )
+}
+
+data class StreamResult(
+    val text: String,
+    val toolCalls: List<ToolCallInfo>,
+)

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/dtos/anthropic/AnthropicChatRequestDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/dtos/anthropic/AnthropicChatRequestDto.kt
@@ -10,6 +10,7 @@ data class AnthropicChatRequestDto(
     val max_tokens: Int = 8192,
     val system: String? = null,
     val tools: List<Tool>? = null,
+    val stream: Boolean? = null,
 ) {
     @Serializable
     data class Message(

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/dtos/openaicompatible/OpenAICompatibleChatRequestDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/dtos/openaicompatible/OpenAICompatibleChatRequestDto.kt
@@ -9,6 +9,7 @@ data class OpenAICompatibleChatRequestDto(
     val messages: List<Message>,
     val model: String? = null,
     val tools: List<Tool>? = null,
+    val stream: Boolean? = null,
 ) {
     @Serializable
     data class Message(


### PR DESCRIPTION
Currently, the app only supports batch text generation, which forces users to wait until the entire response is completed. For longer outputs, this significantly harms the user experience as it feels like the app has frozen. 

By implementing real-time SSE streaming, users can see the response token-by-token instantly. I also added a fallback mechanism to the existing batch implementation so that if streaming fails for any reason, it gracefully switches back to batch mode without interrupting the conversation.

- Add StreamEvent model (Token, ToolCalls, Finished, Error) and accumulator
- Add SseParser for line-by-line SSE reading from Ktor ByteReadChannel
- Add OpenAICompatibleStreamParser for OpenAI-compatible SSE chunks
- Add AnthropicStreamParser for Anthropic SSE events
- Add streamingOpenAICompatibleChat() and streamingAnthropicChat() to Requests
- Add stream field to request DTOs
- Add streamingChat() to ToolLoopStrategy with batch fallback
- Use placeholder History entries updated token-by-token in runToolLoop
- Graceful fallback to batch API calls when streaming fails