### PR TITLE
Stable prompt caching - Performance and cost improvements

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/ChatSystemPromptBuilder.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/ChatSystemPromptBuilder.kt
@@ -1,5 +1,3 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class)
-
 // Pure builders for the chat system prompt. Every input is passed explicitly — no DI,
 // no suspend, no resource loading, no Clock — so tests can call `buildChatSystemPrompt`
 // directly with hand-crafted inputs. Section composition is controlled by
@@ -32,12 +30,8 @@ enum class SystemPromptVariant {
 
 /** Runtime state rendered into the `## Context` section. */
 internal data class ChatPromptRuntimeContext(
-    /** Local-zoned ISO 8601 with explicit offset, e.g. `2026-04-22T22:32:39+02:00`. */
-    val nowLocalIsoWithOffset: String,
-    /** IANA zone id, e.g. `Europe/Berlin`. Rendered next to the local time for clarity. */
+    /** IANA zone id, e.g. `Europe/Berlin`. Used by schedule_task to interpret naive datetimes. */
     val timeZoneId: String,
-    /** UTC ISO 8601 with `Z` suffix — kept so the model can double-check the offset. */
-    val nowUtcIsoString: String,
     val platform: String,
     val modelId: String,
     val providerName: String,
@@ -322,11 +316,9 @@ private fun StringBuilder.appendEmailAccountsSection(accounts: List<EmailAccount
         } else {
             append(account.unreadCount)
             append(" unread")
-            if (account.lastSyncEpochMs > 0) {
-                append(" (last sync: ")
-                append(Instant.fromEpochMilliseconds(account.lastSyncEpochMs))
-                append(')')
-            }
+            // lastSyncEpochMs is intentionally omitted here: an absolute timestamp in the
+            // system prompt would change on every email sync and bust the prompt-cache
+            // breakpoint. The AI can call email tools for fresh sync status if needed.
         }
         append('\n')
     }
@@ -367,16 +359,12 @@ private fun StringBuilder.appendScheduledTasksSection(pendingTasks: List<Schedul
 
 private fun StringBuilder.appendContextSection(runtime: ChatPromptRuntimeContext) {
     append("\n\n## Context\n")
-    // Lead with local time so the model anchors on the user's wall clock when computing
-    // relative times ("in 3 minutes", "tomorrow at 9"). Tools that accept a naive datetime
-    // (e.g. `schedule_task`'s `execute_at`) interpret it in this zone.
-    append("- Local time: ")
-    append(runtime.nowLocalIsoWithOffset)
-    append(" (")
+    // The timezone is stable (only changes if the user changes their device zone) and is
+    // needed so schedule_task can interpret naive datetimes in the user's local zone.
+    // The actual current time is prepended to each user message instead, so it never
+    // busts the system prompt prefix cache.
+    append("- Timezone: ")
     append(runtime.timeZoneId)
-    append(")\n")
-    append("- UTC: ")
-    append(runtime.nowUtcIsoString)
     append('\n')
     append("- Platform: ")
     append(runtime.platform)

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/RemoteDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/RemoteDataRepository.kt
@@ -70,8 +70,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.offsetAt
-import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -621,7 +619,10 @@ class RemoteDataRepository(
                 if (tools.isNotEmpty()) {
                     handleGeminiChatWithTools(creds, messages, tools, systemPrompt, history)
                 } else {
-                    val geminiMessages = messages.map { it.toGeminiMessageDto() }
+                    val lastUserIndex = messages.indexOfLast { it.role == History.Role.USER }
+                    val geminiMessages = messages.mapIndexed { index, msg ->
+                        msg.toGeminiMessageDto(addTimestamp = (msg.role == History.Role.USER && index == lastUserIndex))
+                    }
                     val response = requests.geminiChat(creds, geminiMessages, systemInstruction = systemPrompt).getOrThrow()
                     AssistantTurn(response.extractText())
                 }
@@ -918,7 +919,10 @@ class RemoteDataRepository(
         val contextWindowTokens = ModelCatalog.estimateContextWindow(credentials.modelId)
         val strategy = object : ToolLoopStrategy {
             override suspend fun chat(history: List<History>, systemPrompt: String?): LoopChatResult {
-                val geminiMessages = history.map { it.toGeminiMessageDto() }
+                val lastUserIndex = history.indexOfLast { it.role == History.Role.USER }
+                val geminiMessages = history.mapIndexed { index, msg ->
+                    msg.toGeminiMessageDto(addTimestamp = msg.role == History.Role.USER && index == lastUserIndex)
+                }
                 val response = retryApiCall {
                     requests.geminiChat(
                         credentials = credentials,
@@ -948,7 +952,10 @@ class RemoteDataRepository(
                     BailoutReason.LIMIT_REACHED -> "You have reached the tool call limit. Please respond with the best answer you have so far based on the information gathered."
                     BailoutReason.REPEATING -> "You are repeating the same tool calls. Please respond with the best answer you have so far."
                 }
-                val geminiMessages = history.map { it.toGeminiMessageDto() }
+                val lastUserIndex = history.indexOfLast { it.role == History.Role.USER }
+                val geminiMessages = history.mapIndexed { index, msg ->
+                    msg.toGeminiMessageDto(addTimestamp = msg.role == History.Role.USER && index == lastUserIndex)
+                }
                 val bailoutResponse = retryApiCall {
                     requests.geminiChat(
                         credentials = credentials,
@@ -1661,14 +1668,9 @@ class RemoteDataRepository(
                 ""
             }
         }
-        val now = Clock.System.now()
         val timeZone = TimeZone.currentSystemDefault()
-        val localDateTime = now.toLocalDateTime(timeZone)
-        val offset = timeZone.offsetAt(now)
         val runtime = ChatPromptRuntimeContext(
-            nowLocalIsoWithOffset = "$localDateTime$offset",
             timeZoneId = timeZone.id,
-            nowUtcIsoString = now.toString(),
             platform = currentPlatform.displayName,
             modelId = modelId,
             providerName = service.displayName,
@@ -1980,7 +1982,10 @@ class RemoteDataRepository(
 
         val responseText = when (service) {
             Service.Gemini -> {
-                val geminiMessages = messages.map { it.toGeminiMessageDto() }
+                val lastUserIndex = messages.indexOfLast { it.role == History.Role.USER }
+                val geminiMessages = messages.mapIndexed { index, msg ->
+                    msg.toGeminiMessageDto(addTimestamp = (msg.role == History.Role.USER && index == lastUserIndex))
+                }
                 val response = requests.geminiChat(creds, geminiMessages, systemInstruction = systemPrompt).getOrThrow()
                 response.extractText()
             }
@@ -2016,7 +2021,10 @@ class RemoteDataRepository(
 
         return when (service) {
             Service.Gemini -> {
-                val geminiMessages = messages.map { it.toGeminiMessageDto() }
+                val lastUserIndex = messages.indexOfLast { it.role == History.Role.USER }
+                val geminiMessages = messages.mapIndexed { index, msg ->
+                    msg.toGeminiMessageDto(addTimestamp = (msg.role == History.Role.USER && index == lastUserIndex))
+                }
                 val response = requests.geminiChat(creds, geminiMessages, requestTimeoutMs = reqTimeout).getOrThrow()
                 response.extractText()
             }

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/providers/AnthropicMessages.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/providers/AnthropicMessages.kt
@@ -9,9 +9,16 @@ import kotlinx.serialization.json.JsonElement
 internal fun buildAnthropicMessages(
     messages: List<History>,
 ): List<AnthropicChatRequestDto.Message> = buildList {
+    // Mark the penultimate user turn with a cache breakpoint so the accumulated
+    // conversation history is reused on the next request. The last user message
+    // is always new, so caching it gives zero benefit.
+    val userIndices = messages.indices.filter { messages[it].role == History.Role.USER }
+    val cacheBreakpointIndex = if (userIndices.size >= 2) userIndices[userIndices.size - 2] else -1
+    val lastUserIndex = userIndices.lastOrNull() ?: -1
+
     var pendingToolResults = mutableListOf<JsonElement>()
 
-    for (msg in messages) {
+    for ((index, msg) in messages.withIndex()) {
         when (msg.role) {
             History.Role.TOOL_EXECUTING -> { /* skip */ }
 
@@ -32,10 +39,12 @@ internal fun buildAnthropicMessages(
                     )
                     pendingToolResults = mutableListOf()
                 }
+                val addCache = index == cacheBreakpointIndex
+                val addTimestamp = msg.role == History.Role.USER && index == lastUserIndex
                 add(
                     AnthropicChatRequestDto.Message(
                         role = if (msg.role == History.Role.ASSISTANT) "assistant" else "user",
-                        content = msg.toAnthropicContentBlocks(),
+                        content = msg.toAnthropicContentBlocks(addCacheBreakpoint = addCache, addTimestamp = addTimestamp),
                     ),
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/providers/OpenAIMessages.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/providers/OpenAIMessages.kt
@@ -25,9 +25,16 @@ internal fun buildOpenAIMessages(
             ),
         )
     }
+    val lastUserIndex = messages.indexOfLast { it.role == History.Role.USER }
     addAll(
         sanitizeToolMessages(
-            messages.map { it.toGroqMessageDto(service.reasoningRequestMode, supportsImages) },
+            messages.mapIndexed { index, msg ->
+                msg.toGroqMessageDto(
+                    reasoningMode = service.reasoningRequestMode,
+                    supportsImages = service.supportsImages,
+                    addTimestamp = msg.role == History.Role.USER && index == lastUserIndex,
+                )
+            },
             declaredToolNames,
         ),
     )

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/Requests.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/Requests.kt
@@ -43,10 +43,12 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import kotlin.time.Duration.Companion.seconds
 
 data class ServiceCredentials(
@@ -186,9 +188,10 @@ class Requests {
         val apiKey = getApiKeyOrThrow(service, credentials)
         val model = credentials.modelId.ifEmpty { null }
         val url = resolveUrl(service, credentials, service.chatUrl)
+        val effectiveTimeoutMs = requestTimeoutMs ?: if (service == Service.OpenAICompatible) 120.seconds.inWholeMilliseconds else null
         val response: HttpResponse =
             defaultClient.post(url) {
-                requestTimeoutMs?.let {
+                effectiveTimeoutMs?.let {
                     timeout {
                         requestTimeoutMillis = it
                         socketTimeoutMillis = it
@@ -313,12 +316,23 @@ class Requests {
                 contentType(ContentType.Application.Json)
                 header("x-api-key", apiKey)
                 header("anthropic-version", "2023-06-01")
+                header("anthropic-beta", "prompt-caching-2024-07-31")
                 setBody(
                     AnthropicChatRequestDto(
                         model = credentials.modelId,
                         messages = messages,
                         max_tokens = 8192,
-                        system = systemInstruction,
+                        system = systemInstruction?.let { text ->
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("type", "text")
+                                        put("text", text)
+                                        put("cache_control", buildJsonObject { put("type", "ephemeral") })
+                                    },
+                                ),
+                            )
+                        },
                         tools = tools.mapNotNull { runCatching { it.toAnthropicTool() }.getOrNull() }
                             .ifEmpty { null },
                     ),

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/dtos/anthropic/AnthropicChatRequestDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/network/dtos/anthropic/AnthropicChatRequestDto.kt
@@ -8,7 +8,7 @@ data class AnthropicChatRequestDto(
     val model: String,
     val messages: List<Message>,
     val max_tokens: Int = 8192,
-    val system: String? = null,
+    val system: JsonElement? = null,
     val tools: List<Tool>? = null,
 ) {
     @Serializable

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/tools/SchedulingTools.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/tools/SchedulingTools.kt
@@ -35,7 +35,7 @@ object SchedulingTools {
     fun scheduleTaskTool(taskStore: TaskStore) = object : Tool {
         override val schema = ToolSchema(
             name = "schedule_task",
-            description = "Schedule a prompt to run later, recurring, or on every heartbeat. This is the ONLY way to run something after this turn — reminders, follow-ups, periodic updates, check-ins, standing heartbeat additions (greetings, always-summarise-emails): all go through this tool. Each run starts a fresh conversation, so embed the context the prompt needs. Exactly one trigger must be provided: execute_at (one-off at a datetime), cron (recurring on a schedule), or on_heartbeat=true (appended to every heartbeat self-check). Schedule relative to the **Local time** shown in `## Context`, not UTC.",
+            description = "Schedule a prompt to run later, recurring, or on every heartbeat. This is the ONLY way to run something after this turn — reminders, follow-ups, periodic updates, check-ins, standing heartbeat additions (greetings, always-summarise-emails): all go through this tool. Each run starts a fresh conversation, so embed the context the prompt needs. Exactly one trigger must be provided: execute_at (one-off at a datetime), cron (recurring on a schedule), or on_heartbeat=true (appended to every heartbeat self-check). Schedule relative to the **current time** prepended to this message, not UTC.",
             parameters = mapOf(
                 "description" to ParameterSchema(type = "string", description = "Human-readable description of the task", required = true),
                 "prompt" to ParameterSchema(type = "string", description = "For execute_at/cron: the full prompt sent to the AI when it fires. For on_heartbeat: the instruction appended to each heartbeat self-check (e.g. 'Greet the user warmly with a time-appropriate greeting.').", required = true),
@@ -78,7 +78,7 @@ object SchedulingTools {
                 if (parsed < nowMs - PAST_INSTANT_SLACK_MS) {
                     return mapOf(
                         "success" to false,
-                        "error" to "execute_at ($executeAt) is in the past — check the Local time in Context and retry (use an offset-qualified value like 2025-03-15T09:00:00+02:00 to avoid UTC/local ambiguity)",
+                        "error" to "execute_at ($executeAt) is in the past — check the current time prepended to this message and retry (use an offset-qualified value like 2025-03-15T09:00:00+02:00 to avoid UTC/local ambiguity)",
                     )
                 }
                 parsed

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/ui/chat/ChatUiState.kt
@@ -17,6 +17,8 @@ import io.github.vinceglb.filekit.PlatformFile
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -26,6 +28,7 @@ import kotlinx.serialization.json.put
 import org.jetbrains.compose.resources.StringResource
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -56,6 +59,36 @@ private fun List<Attachment>.splitForMessage(): AttachmentSplit {
         }
     }
     return AttachmentSplit(prefix.toString(), binaries)
+}
+
+/**
+ * Returns a human-readable local-time string to prepend to outgoing user messages,
+ * giving the model accurate time context on every turn without invalidating the
+ * system prompt prefix cache.
+ *
+ * Format example: "2:58 PM (April 25, 2026)"
+ *
+ * Uses the device's configured timezone via TimeZone.currentSystemDefault().
+ * Timezone abbreviations (EDT/EST) are omitted because kotlinx.datetime does not
+ * expose them in a cross-platform way; the date/time itself is unambiguous.
+ */
+private fun getLocalTimeString(): String {
+    val now = Clock.System.now()
+    val zone = TimeZone.currentSystemDefault()
+    val local = now.toLocalDateTime(zone)
+
+    val hour12 = when {
+        local.hour == 0 -> 12
+        local.hour <= 12 -> local.hour
+        else -> local.hour - 12
+    }
+    val amPm = if (local.hour < 12) "AM" else "PM"
+    val minute = local.minute.toString().padStart(2, '0')
+    val monthName = local.month.name
+        .lowercase()
+        .replaceFirstChar { it.uppercase() }
+
+    return "$hour12:$minute $amPm ($monthName ${local.day}, ${local.year})"
 }
 
 @Immutable
@@ -135,6 +168,7 @@ data class ToolCallInfo(
 fun History.toGroqMessageDto(
     reasoningMode: ReasoningRequestMode = ReasoningRequestMode.NONE,
     supportsImages: Boolean = true,
+    addTimestamp: Boolean = false,
 ): OpenAICompatibleChatRequestDto.Message = when (role) {
     History.Role.USER -> {
         val split = attachments.splitForMessage()
@@ -147,7 +181,8 @@ fun History.toGroqMessageDto(
         } else {
             emptyList()
         }
-        val fullText = "${split.textPrefix}$content"
+        val timestampStr = if (addTimestamp) "[System Time: ${getLocalTimeString()}]\n\n" else ""
+        val fullText = "${split.textPrefix}$timestampStr$content"
         val messageContent: JsonElement = if (imageAttachments.isEmpty()) {
             JsonPrimitive(fullText)
         } else {
@@ -216,13 +251,22 @@ fun History.toGroqMessageDto(
     History.Role.TOOL_EXECUTING -> OpenAICompatibleChatRequestDto.Message(role = "assistant", content = JsonPrimitive(content))
 }
 
-fun History.toAnthropicContentBlocks(): JsonElement = when (role) {
+fun History.toAnthropicContentBlocks(addCacheBreakpoint: Boolean = false, addTimestamp: Boolean = false): JsonElement = when (role) {
     History.Role.USER -> {
         val split = attachments.splitForMessage()
-        val fullText = "${split.textPrefix}$content"
-        if (split.binaries.isEmpty()) {
+        val timestampStr = if (addTimestamp) "[System Time: ${getLocalTimeString()}]\n\n" else ""
+        val fullText = "${split.textPrefix}$timestampStr$content"
+        if (split.binaries.isEmpty() && !addCacheBreakpoint) {
+            // No attachments, no cache marker: keep original compact form
             JsonPrimitive(fullText)
         } else {
+            val textBlock = buildJsonObject {
+                put("type", "text")
+                put("text", fullText)
+                if (addCacheBreakpoint) {
+                    put("cache_control", buildJsonObject { put("type", "ephemeral") })
+                }
+            }
             JsonArray(
                 buildList {
                     for (att in split.binaries) {
@@ -256,12 +300,7 @@ fun History.toAnthropicContentBlocks(): JsonElement = when (role) {
                             )
                         }
                     }
-                    add(
-                        buildJsonObject {
-                            put("type", "text")
-                            put("text", fullText)
-                        },
-                    )
+                    add(textBlock)
                 },
             )
         }
@@ -269,6 +308,12 @@ fun History.toAnthropicContentBlocks(): JsonElement = when (role) {
 
     History.Role.ASSISTANT -> {
         if (toolCalls != null) {
+            // TODO: If Anthropic extended thinking is ever enabled (anthropic-beta:
+            //  interleaved-thinking-2025-05-14 + a `thinking` param in the request),
+            //  thinking blocks MUST be echoed back verbatim in subsequent messages.
+            //  Add {"type":"thinking","thinking":...,"signature":...} blocks here
+            //  (sourced from History.reasoningContent) before the text/tool_use blocks,
+            //  otherwise Anthropic will reject tool-loop continuations with an API error.
             JsonArray(
                 buildList {
                     if (content.isNotEmpty()) {
@@ -313,7 +358,7 @@ fun History.toAnthropicContentBlocks(): JsonElement = when (role) {
 
 private val geminiJsonParser = SharedJson
 
-fun History.toGeminiMessageDto(): GeminiChatRequestDto.Content {
+fun History.toGeminiMessageDto(addTimestamp: Boolean = false): GeminiChatRequestDto.Content {
     // Gemini uses "user" for tool responses (functionResponse), not "tool"
     val geminiRole = when (role) {
         History.Role.USER -> "user"
@@ -389,7 +434,8 @@ fun History.toGeminiMessageDto(): GeminiChatRequestDto.Content {
                             ),
                         )
                     }
-                    add(GeminiChatRequestDto.Part(text = "${split.textPrefix}$content"))
+                    val timestampStr = if (addTimestamp) "[System Time: ${getLocalTimeString()}]\n\n" else ""
+                    add(GeminiChatRequestDto.Part(text = "${split.textPrefix}$timestampStr$content"))
                 }
             }
         },

--- a/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/data/ChatSystemPromptBuilderTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/data/ChatSystemPromptBuilderTest.kt
@@ -16,9 +16,7 @@ import kotlin.test.assertTrue
 class ChatSystemPromptBuilderTest {
 
     private val runtime = ChatPromptRuntimeContext(
-        nowLocalIsoWithOffset = "2026-04-11T02:00:00+02:00",
         timeZoneId = "Europe/Berlin",
-        nowUtcIsoString = "2026-04-11T00:00:00Z",
         platform = "Test",
         modelId = "test-model",
         providerName = "Test Provider",
@@ -128,8 +126,7 @@ class ChatSystemPromptBuilderTest {
         assertTrue("## Structured Learning" in out)
         assertTrue("## Automation" in out)
         assertTrue("## Context" in out)
-        assertTrue("- Local time: 2026-04-11T02:00:00+02:00 (Europe/Berlin)" in out)
-        assertTrue("- UTC: 2026-04-11T00:00:00Z" in out)
+        assertTrue("- Timezone: Europe/Berlin" in out)
         assertTrue("- Platform: Test" in out)
         assertTrue("- Model: test-model" in out)
         assertTrue("- Provider: Test Provider" in out)
@@ -236,8 +233,7 @@ class ChatSystemPromptBuilderTest {
             DEFAULT_HONESTY_RULE + "\n\n" +
             DEFAULT_ACTING_SECTION + "\n\n" +
             "## Context\n" +
-            "- Local time: 2026-04-11T02:00:00+02:00 (Europe/Berlin)\n" +
-            "- UTC: 2026-04-11T00:00:00Z\n" +
+            "- Timezone: Europe/Berlin\n" +
             "- Platform: Test\n" +
             "- Model: test-model\n" +
             "- Provider: Test Provider\n"
@@ -605,8 +601,7 @@ class ChatSystemPromptBuilderTest {
             DEFAULT_ACTING_SECTION + "\n\n" +
             "Save user preferences with memory_store.\n\n" +
             "## Context\n" +
-            "- Local time: 2026-04-11T02:00:00+02:00 (Europe/Berlin)\n" +
-            "- UTC: 2026-04-11T00:00:00Z\n" +
+            "- Timezone: Europe/Berlin\n" +
             "- Platform: Test\n" +
             "- Model: test-model\n" +
             "- Provider: Test Provider\n"

--- a/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/tools/SchedulingToolsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/tools/SchedulingToolsTest.kt
@@ -68,7 +68,7 @@ class SchedulingToolsTest {
         assertEquals(false, result["success"])
         val error = result["error"]?.toString().orEmpty()
         assertTrue("in the past" in error, "error should mention past: $error")
-        assertTrue("Local time" in error, "error should point at Local time: $error")
+        assertTrue("current time" in error, "error should point at current time: $error")
     }
 
     @Test
@@ -98,6 +98,6 @@ class SchedulingToolsTest {
         val schema = SchedulingTools.scheduleTaskTool(freshStore()).schema
         val executeAtDesc = schema.parameters["execute_at"]?.description.orEmpty()
         assertTrue("local timezone" in executeAtDesc, "execute_at should explain local-vs-offset: $executeAtDesc")
-        assertTrue("Local time" in schema.description, "top-level description should reference Local time: ${schema.description}")
+        assertTrue("current time" in schema.description, "top-level description should reference current time: ${schema.description}")
     }
 }

--- a/docs/features/system-prompts.md
+++ b/docs/features/system-prompts.md
@@ -1,6 +1,6 @@
 # System Prompts
 
-**Last verified:** 2026-05-30
+**Last verified:** 2026-06-24
 
 Kai has several distinct prompt-construction paths. Each one is built by a **pure function** with explicit inputs (no DI, no suspend, no resource loading, no clocks) and is covered by a unit-test suite so future edits don't silently break unrelated variations.
 
@@ -36,7 +36,7 @@ The on-device tool allowlist (`LOCAL_TOOL_ALLOWLIST` in `RemoteDataRepository.kt
 | `## Scheduled Tasks` | when list non-empty | never | `pendingTasks` (time/cron only; heartbeat-trigger tasks live in the next section) |
 | `## Heartbeat Additions` | when list non-empty | never | `heartbeatAdditions` — standing `schedule_task(on_heartbeat=true)` entries the AI can see/reference/cancel |
 | `## Active skill: <name>` | when activated | when activated | `activeSkill` param — non-null only when the user prefixed the current turn's message with `/<skill-id>` matching an installed, enabled skill. Emits the skill's instruction body plus a list of any bundled files (available at `~/skills/<id>/` in the sandbox). Zero bytes on every other turn. See [skills.md](skills.md) |
-| `## Context` | always | always | `runtime` param (local time with offset + IANA zone, UTC, platform, model, provider). Local time leads so the model anchors on the user's wall clock when computing relative times |
+| `## Context` | always | always | `runtime` param (IANA zone, platform, model, provider). The current date/time is deliberately left out here — it's prepended to the latest user message instead, so this section stays identical turn to turn and providers can cache it. The timezone alone is kept since tools that accept naive datetimes still need it |
 | `## Dynamic UI` | when `uiMode = DYNAMIC_UI` | never | `uiMode` param |
 | `## Interactive UI Mode` | when `uiMode = INTERACTIVE_UI` | never | `uiMode` param |
 

--- a/docs/features/tasks.md
+++ b/docs/features/tasks.md
@@ -1,6 +1,6 @@
 # Tasks
 
-**Last verified:** 2026-05-14
+**Last verified:** 2026-06-24
 
 Kai's tasks feature enables the AI to schedule one-time or recurring actions for future execution. Tasks are created through AI tools, stored persistently, and executed automatically by a background scheduler that polls on a fixed interval.
 
@@ -62,8 +62,8 @@ A 5-field schedule format (`minute hour day-of-month month day-of-week`) used fo
 ### schedule_task Validation
 
 - **Exactly one** of `execute_at` (ISO 8601), `cron`, or `on_heartbeat: true` must be provided — they are mutually exclusive
-- `execute_at` accepts offset-qualified (`2026-04-22T22:32:39+02:00`, `...Z`) or naive (`2026-04-22T22:32:39`) values. Naive values are interpreted in the user's local timezone, which is surfaced to the AI via the `## Context` block's `Local time` line. Offset-qualified form is preferred to avoid UTC/local ambiguity
-- Past-dated `execute_at` values (more than a minute before now) are rejected at tool-call time with an error that points at the `Local time` context — most often this is a UTC/local sign flip that the model can correct on retry
+- `execute_at` accepts offset-qualified (`2026-04-22T22:32:39+02:00`, `...Z`) or naive (`2026-04-22T22:32:39`) values. Naive values are interpreted in the user's local timezone, which is surfaced to the AI via the `## Context` block's `Timezone` line; the current local time itself is prepended to the latest user message rather than living in `## Context`, so the system prompt stays cacheable. Offset-qualified form is preferred to avoid UTC/local ambiguity
+- Past-dated `execute_at` values (more than a minute before now) are rejected at tool-call time with an error that points at the current time prepended to the message — most often this is a UTC/local sign flip that the model can correct on retry
 - Returns the created task's id, description, trigger, scheduled time, and cron expression
 
 ### Heartbeat-triggered tasks

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ spght-encryptedprefs = { module = "dev.spght:encryptedprefs-ktx", version.ref = 
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
-androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version = "2.11.0" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationComposeVersion" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }


### PR DESCRIPTION
- Moves the current date/time out of the system prompt's ## Context section (which busted the prompt cache on every request) and prepends it to the latest user message instead. ## Context now only carries the stable IANA timezone.
- Adds Anthropic ephemeral cache_control on the system prompt block and a cache breakpoint on the penultimate user turn, so accumulated conversation history is reused across requests.
- Bumps the default request timeout for OpenAI-compatible services (local llama.cpp/Ollama/LM Studio backends) from 60s to 120s — long local-context generations without token streaming were frequently timing out and retriggering a duplicate request.
- Updates schedule_task's tool description/error copy and the two affected feature docs (system-prompts.md, tasks.md) to match. They previously pointed the AI at a "Local time" context line that this change removes.