### PR TITLE
Correct MiniMax-M2.7 context window to 204,800 tokens

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/ModelCatalog.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/kai/data/ModelCatalog.kt
@@ -449,7 +449,9 @@ internal object ModelCatalog {
         // MiniMax
         // ==============================================================
         "minimax-m3" to CuratedModelInfo("MiniMax M3", 1_000_000, "2026-05"),
-        "minimax-m2.7" to CuratedModelInfo("MiniMax M2.7", 1_000_000, "2026-03"),
+        // MiniMax-M2.7 is a 204,800-token model; don't reuse the 1,000,000 figure
+        // reserved for the larger MiniMax models.
+        "minimax-m2.7" to CuratedModelInfo("MiniMax M2.7", 204_800, "2026-03"),
         "minimax-m2.5-free" to CuratedModelInfo("MiniMax M2.5 (Free)", 1_000_000, "2025-12"),
         "minimax-m2" to CuratedModelInfo("MiniMax M2", 1_000_000, "2025-10"),
         "minimax-m1" to CuratedModelInfo("MiniMax M1", 1_000_000, "2025-06"),

--- a/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/data/ModelCatalogTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/inspiredandroid/kai/data/ModelCatalogTest.kt
@@ -118,6 +118,14 @@ class ModelCatalogTest {
     }
 
     @Test
+    fun `minimax m2 7 context window is 204800 not the larger models figure`() {
+        val m27 = ModelCatalog.lookup("minimax-m2.7")
+        assertNotNull(m27)
+        assertEquals("MiniMax M2.7", m27.displayName)
+        assertEquals(204_800, m27.contextWindow)
+    }
+
+    @Test
     fun `horde-style path ids resolve via last segment`() {
         val cydonia = ModelCatalog.lookup("aphrodite/TheDrummer/Cydonia-24B-v4.3")
         assertNotNull(cydonia)


### PR DESCRIPTION
Reason: MiniMax-M2.7 exposes a 204,800-token context window, not the 1,000,000-token figure the curated catalog reused from the larger MiniMax models.

## Changes

- `ModelCatalog.kt`: set the `minimax-m2.7` curated entry's context window to `204_800` (was `1_000_000`).
- `ModelCatalogTest.kt`: add a regression test asserting `minimax-m2.7` resolves to `MiniMax M2.7` with a `204_800` context window.

## Checks

- `./gradlew :composeApp:desktopTest --tests 'com.inspiredandroid.kai.data.ModelCatalogTest'` — `BUILD SUCCESSFUL`, 14 tests, 0 failures.
